### PR TITLE
fix user selection limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -362,7 +362,8 @@
     "shaoye",
     "charlej",
     "emlez",
-    "hendrikbunnick"
+    "hendrikbunnick",
+    "romanschmid"
   ],
   "dependencies": {
     "@apollo/client": "^3.4.8",

--- a/src/gitlabapi.ts
+++ b/src/gitlabapi.ts
@@ -560,7 +560,7 @@ export class GitLab {
   }
 
   async getProjectMember(projectId: number): Promise<User[]> {
-    const userItems: User[] = await this.fetch(`projects/${projectId}/users`).then((users) => {
+    const userItems: User[] = await this.fetch(`projects/${projectId}/users`, {}, true).then((users) => {
       return users.map((userdata: any) => ({
         id: userdata.id,
         name: userdata.name,


### PR DESCRIPTION
Fixed a limit of 50 users for user selection during Create Merge Request / Create Issue. 
When working on a project with 50+ people, users that are not fetched within the 50 item page limit do not appear in the user selection box.